### PR TITLE
Update sfdx-lwc-jest bin name

### DIFF
--- a/messages/run.json
+++ b/messages/run.json
@@ -7,7 +7,7 @@
   "debugFlagLongDescription": "Runs tests in a Node process that an external debugger can connect to. The run pauses until the debugger is connected. For more information, see: https://jestjs.io/docs/en/troubleshooting",
   "watchFlagDescription": "run tests in watch mode",
   "watchFlagLongDescription": "Runs tests when a watched file changes. Watched files include the component under test and any files it references.",
-  "errorNoExecutableFound": "No lwc-jest executable found. Verify it is properly installed.\nRun \"sfdx force:lightning:lwc:test:setup --help\" for installation details.",
+  "errorNoExecutableFound": "No sfdx-lwc-jest executable found. Verify it is properly installed.\nRun \"sfdx force:lightning:lwc:test:setup --help\" for installation details.",
   "errorInvalidFlags": "Specify only --debug or --watch, not both.",
   "logSuccess": "Test run complete. Exited with status code: %s"
 }

--- a/messages/setup.json
+++ b/messages/setup.json
@@ -6,6 +6,7 @@
   "errorNpmNotFound": "npm command not found. Verify npm is properly installed and try again.",
   "errorNodeVersion": "Node.js version too low. Version 8.12.0 or higher required. Found version %s",
   "errorNoPackageJson": "No package.json found at root of project. Run \"npm init\" to create one.",
+  "errorLwcJestInstall": "Error installing @salesforce/sfdx-lwc-jest: %o",
   "logSuccess": "Test setup complete.",
   "logFileUpdatesStart": "Updating files...",
   "logFileUpdatesEnd": "File modifications complete.",

--- a/messages/setup.json
+++ b/messages/setup.json
@@ -6,7 +6,6 @@
   "errorNpmNotFound": "npm command not found. Verify npm is properly installed and try again.",
   "errorNodeVersion": "Node.js version too low. Version 8.12.0 or higher required. Found version %s",
   "errorNoPackageJson": "No package.json found at root of project. Run \"npm init\" to create one.",
-  "errorLwcJestInstall": "Error installing @salesforce/sfdx-lwc-jest: %o",
   "logSuccess": "Test setup complete.",
   "logFileUpdatesStart": "Updating files...",
   "logFileUpdatesEnd": "File modifications complete.",

--- a/src/commands/force/lightning/lwc/test/run.ts
+++ b/src/commands/force/lightning/lwc/test/run.ts
@@ -79,8 +79,8 @@ export default class Run extends SfdxCommand {
   private getExecutablePath() {
     const projectPath = this.project.getPath();
     const nodeModulePath = process.platform === 'win32' ?
-      path.join('@salesforce', 'sfdx-lwc-jest', 'bin', 'lwc-jest') :
-      path.join('.bin', 'lwc-jest');
+      path.join('@salesforce', 'sfdx-lwc-jest', 'bin', 'sfdx-lwc-jest') :
+      path.join('.bin', 'sfdx-lwc-jest');
 
     const executablePath = path.join(projectPath, 'node_modules', nodeModulePath);
     if (!fs.existsSync(executablePath)) {

--- a/src/commands/force/lightning/lwc/test/setup.ts
+++ b/src/commands/force/lightning/lwc/test/setup.ts
@@ -17,9 +17,9 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/sfdx-plugin-lwc-test', 'setup');
 
 const testScripts = {
-  'test:unit': 'lwc-jest',
-  'test:unit:debug': 'lwc-jest --debug',
-  'test:unit:watch': 'lwc-jest --watch'
+  'test:unit': 'sfdx-lwc-jest',
+  'test:unit:debug': 'sfdx-lwc-jest --debug',
+  'test:unit:watch': 'sfdx-lwc-jest --watch'
 };
 
 const jestConfig = `const { jestConfig } = require('@salesforce/sfdx-lwc-jest/config');
@@ -129,16 +129,12 @@ export default class Setup extends SfdxCommand {
 
   private installLwcJest(): void {
     this.ux.log('Installing @salesforce/sfdx-lwc-jest node package...');
-    let lwcJestInstallRet;
     const yarnLockExists = fs.existsSync(path.join(this.project.getPath(), 'yarn.lock'));
     if (yarnLockExists) {
       this.ux.log('Detected yarn.lock file, using yarn commands');
-      lwcJestInstallRet = execSync('yarn add --dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
+      execSync('yarn add --dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
     } else {
-      lwcJestInstallRet = execSync('npm install --save-dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
-    }
-    if (lwcJestInstallRet.error) {
-      throw new SfdxError(messages.getMessage('errorLwcJestInstall', [lwcJestInstallRet.error.message]));
+      execSync('npm install --save-dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
     }
   }
 }

--- a/src/commands/force/lightning/lwc/test/setup.ts
+++ b/src/commands/force/lightning/lwc/test/setup.ts
@@ -129,12 +129,16 @@ export default class Setup extends SfdxCommand {
 
   private installLwcJest(): void {
     this.ux.log('Installing @salesforce/sfdx-lwc-jest node package...');
-    const yarnLockExists = fs.existsSync(path.join(this.project.getPath(), 'yarn.lock'));
-    if (yarnLockExists) {
-      this.ux.log('Detected yarn.lock file, using yarn commands');
-      execSync('yarn add --dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
-    } else {
-      execSync('npm install --save-dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
+    try {
+      const yarnLockExists = fs.existsSync(path.join(this.project.getPath(), 'yarn.lock'));
+      if (yarnLockExists) {
+        this.ux.log('Detected yarn.lock file, using yarn commands');
+        execSync('yarn add --dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
+      } else {
+        execSync('npm install --save-dev @salesforce/sfdx-lwc-jest', { stdio: 'inherit' });
+      }
+    } catch (e) {
+      throw new SfdxError(messages.getMessage('errorLwcJestInstall', [e.message]));
     }
   }
 }

--- a/test/commands/lwc/test/run.test.ts
+++ b/test/commands/lwc/test/run.test.ts
@@ -102,26 +102,26 @@ describe('force:lightning:lwc:test:run', () => {
     test
     .do(() => {
       stubMethod($$.SANDBOX, child_process, 'spawnSync').returns(successReturn);
-      stubMethod($$.SANDBOX, fs, 'existsSync').withArgs(sinon.match('lwc-jest')).returns(false);
+      stubMethod($$.SANDBOX, fs, 'existsSync').withArgs(sinon.match('sfdx-lwc-jest')).returns(false);
     })
     .stdout()
     .stderr()
     .withProject()
     .command(['force:lightning:lwc:test:run'])
-    .it('logs no executable error when lwc-jest path does not exist', ctx => {
-      expect(ctx.stderr).to.contain('No lwc-jest executable found');
+    .it('logs no executable error when sfdx-lwc-jest path does not exist', ctx => {
+      expect(ctx.stderr).to.contain('No sfdx-lwc-jest executable found');
     });
 
     test
     .do(() => {
       stubMethod($$.SANDBOX, child_process, 'spawnSync').returns(successReturn);
-      stubMethod($$.SANDBOX, fs, 'existsSync').withArgs(sinon.match('lwc-jest')).returns(false);
+      stubMethod($$.SANDBOX, fs, 'existsSync').withArgs(sinon.match('sfdx-lwc-jest')).returns(false);
     })
     .stdout()
     .stderr()
     .withProject()
     .command(['force:lightning:lwc:test:run'])
-    .it('logs no executable error when lwc-jest path does not exist', ctx => {
-      expect(ctx.stderr).to.contain('No lwc-jest executable found');
+    .it('logs no executable error when sfdx-lwc-jest path does not exist', ctx => {
+      expect(ctx.stderr).to.contain('No sfdx-lwc-jest executable found');
     });
 });

--- a/test/commands/lwc/test/setup.test.ts
+++ b/test/commands/lwc/test/setup.test.ts
@@ -132,7 +132,7 @@ describe('force:lightning:lwc:test:setup', () => {
       // first param is the path, just make sure this is the package.json write
       expect(fileWriterStub.queueWrite.args[0][0]).to.contain('package.json');
       // second param is the content - verify contains test scripts
-      expect(fileWriterStub.queueWrite.args[0][1]).to.contain('"test:unit": "lwc-jest"');
+      expect(fileWriterStub.queueWrite.args[0][1]).to.contain('"test:unit": "sfdx-lwc-jest"');
     });
 
     test
@@ -164,7 +164,7 @@ describe('force:lightning:lwc:test:setup', () => {
       // first param is the path, just make sure this is the package.json write
       expect(fileWriterStub.queueWrite.args[0][0]).to.contain('package.json');
       // second param is the content - verify contains test scripts
-      expect(fileWriterStub.queueWrite.args[0][1]).to.contain('"test:unit": "lwc-jest"');
+      expect(fileWriterStub.queueWrite.args[0][1]).to.contain('"test:unit": "sfdx-lwc-jest"');
     });
 
     test


### PR DESCRIPTION
The `lwc-jest` executable has been deprecated for a while. We should always be referencing `sfdx-lwc-jest`. `@salesforce/sfdx-lwc-jest` actually references both executable names in the `bin` field of its package.json so referencing the deprecated name still works on Mac. On Windows, however, we have to reference the executable that's nested inside the package (`node_modules/sfdx-lwc-jest/bin/lwc-jest`) which does not exist.

Also cleaning up how we handle the return of the `execSync` call since we recently converted that call from `spawnSync` and they return differently.

Related Stack Exchange post: https://salesforce.stackexchange.com/questions/308672/sfdx-forcelightninglwctestrun-not-working