### PR TITLE
chore: update @oclif/config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.1",
   "dependencies": {
     "@oclif/command": "^1.8.0",
-    "@oclif/config": "1.13.3",
+    "@oclif/config": "^1.17.0",
     "@oclif/errors": "^1.3.5",
     "@salesforce/command": "^3.0.0",
     "@salesforce/core": "^2.25.1",

--- a/test/commands/lwc/test/create.test.ts
+++ b/test/commands/lwc/test/create.test.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as fs from 'fs';
+import * as sinon from 'sinon';
+import { SinonStub } from "sinon";
 import { expect, test } from '@salesforce/command/lib/test';
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
@@ -15,17 +17,19 @@ const $$ = testSetup();
 describe('force:lightning:lwc:test:create', () => {
   let writeFileSyncStub;
 
+  afterEach(() => {
+    $$.SANDBOX.restore();
+  });
+
   test
     .do(() => {
       // emulate the component under test existing, but the corresponding test file does not
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path === '/path/to/js/foo.js' || path === '/path/to/js/foo.html') {
-          return true;
-        }
-        if (path === '/path/to/js/__tests__/foo.test.js') {
-          return false;
-        }
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match.in(['/path/to/js/foo.js', '/path/to/js/foo.html']))
+        .returns(true)
+        .withArgs('/path/to/js/__tests__/foo.test.js')
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, fs, 'mkdirSync');
       stubMethod($$.SANDBOX, fs, 'writeFileSync');
     })
@@ -38,14 +42,12 @@ describe('force:lightning:lwc:test:create', () => {
 
     test
     .do(() => {
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path === '/path/to/js/foo.js' || path === '/path/to/js/foo.html') {
-          return true;
-        }
-        if (path === '/path/to/js/__tests__/foo.test.js') {
-          return false;
-        }
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match.in(['/path/to/js/foo.js', '/path/to/js/foo.html']))
+        .returns(true)
+        .withArgs('/path/to/js/__tests__/foo.test.js')
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, fs, 'mkdirSync');
       writeFileSyncStub = stubMethod($$.SANDBOX, fs, 'writeFileSync');
     })
@@ -58,14 +60,12 @@ describe('force:lightning:lwc:test:create', () => {
 
     test
     .do(() => {
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path === '/path/to/js/foo.js' || path === '/path/to/js/foo.html') {
-          return true;
-        }
-        if (path === '/path/to/js/__tests__/foo.test.js') {
-          return false;
-        }
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match.in(['/path/to/js/foo.js', '/path/to/js/foo.html']))
+        .returns(true)
+        .withArgs('/path/to/js/__tests__/foo.test.js')
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, fs, 'mkdirSync');
       writeFileSyncStub = stubMethod($$.SANDBOX, fs, 'writeFileSync');
     })
@@ -78,14 +78,12 @@ describe('force:lightning:lwc:test:create', () => {
 
     test
     .do(() => {
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path === '/path/to/js/fooBar.js' || path === '/path/to/js/fooBar.html') {
-          return true;
-        }
-        if (path === '/path/to/js/__tests__/fooBar.test.js') {
-          return false;
-        }
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match.in(['/path/to/js/fooBar.js', '/path/to/js/fooBar.html']))
+        .returns(true)
+        .withArgs('/path/to/js/__tests__/fooBar.test.js')
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, fs, 'mkdirSync');
       writeFileSyncStub = stubMethod($$.SANDBOX, fs, 'writeFileSync');
     })
@@ -98,11 +96,10 @@ describe('force:lightning:lwc:test:create', () => {
 
     test
     .do(() => {
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path === '/path/to/js/foo.js') {
-          return false;
-        }
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs('/path/to/js/foo.js')
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
     })
     .stdout()
     .stderr()
@@ -114,14 +111,10 @@ describe('force:lightning:lwc:test:create', () => {
 
     test
     .do(() => {
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path === '/path/to/js/foo.js' || path === '/path/to/js/foo.html') {
-          return true;
-        }
-        if (path === '/path/to/js/__tests__/foo.test.js') {
-          return true;
-        }
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match.in(['/path/to/js/foo.js', '/path/to/js/foo.html', '/path/to/js/__tests__/foo.test.js']))
+        .returns(true);
+      (fs.existsSync as SinonStub).callThrough();
     })
     .stdout()
     .stderr()

--- a/test/commands/lwc/test/run.test.ts
+++ b/test/commands/lwc/test/run.test.ts
@@ -11,6 +11,7 @@ import { expect, test } from '@salesforce/command/lib/test';
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
 import Run from '../../../../src/commands/force/lightning/lwc/test/run';
+import { SinonStub } from "sinon";
 
 // Mock all things in core, like api, file io, etc.
 const $$ = testSetup();
@@ -19,6 +20,10 @@ const successReturn = { status: 0 };
 
 describe('force:lightning:lwc:test:run', () => {
   let runJestStub;
+
+  afterEach(() => {
+    $$.SANDBOX.restore();
+  });
 
   test
     .do(() => {
@@ -103,6 +108,7 @@ describe('force:lightning:lwc:test:run', () => {
     .do(() => {
       stubMethod($$.SANDBOX, child_process, 'spawnSync').returns(successReturn);
       stubMethod($$.SANDBOX, fs, 'existsSync').withArgs(sinon.match('sfdx-lwc-jest')).returns(false);
+      (fs.existsSync as SinonStub).callThrough();
     })
     .stdout()
     .stderr()
@@ -116,6 +122,7 @@ describe('force:lightning:lwc:test:run', () => {
     .do(() => {
       stubMethod($$.SANDBOX, child_process, 'spawnSync').returns(successReturn);
       stubMethod($$.SANDBOX, fs, 'existsSync').withArgs(sinon.match('sfdx-lwc-jest')).returns(false);
+      (fs.existsSync as SinonStub).callThrough();
     })
     .stdout()
     .stderr()

--- a/test/commands/lwc/test/setup.test.ts
+++ b/test/commands/lwc/test/setup.test.ts
@@ -11,6 +11,7 @@ import { expect, test } from '@salesforce/command/lib/test';
 import { testSetup } from '@salesforce/core/lib/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
 import Setup from '../../../../src/commands/force/lightning/lwc/test/setup';
+import { SinonStub } from "sinon";
 
 // Mock all things in core, like api, file io, etc.
 const $$ = testSetup();
@@ -115,7 +116,10 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match(/.*\/sfdx_core\/local\/package\.json$/))
+        .returns(true);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       // this stub is key. we have a package.json but no "scripts" section
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson').returns({
@@ -145,7 +149,10 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match(/.*\/sfdx_core\/local\/package\.json$/))
+        .returns(true);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson').returns({
         "name": "from test",
@@ -177,7 +184,6 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson').returns({
         "name": 'from test',
@@ -208,7 +214,6 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       stubMethod($$.SANDBOX, Setup.prototype, 'updatePackageJsonScripts');
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson').returns({
@@ -237,7 +242,6 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       stubMethod($$.SANDBOX, Setup.prototype, 'updatePackageJsonScripts');
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson').returns({
@@ -263,15 +267,12 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path.indexOf('package.json') !== -1) {
-          return true;
-        }
-        if (path.indexOf('jest.config.js') !== -1) {
-          return false;
-        }
-        return true;
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match(sinon.match(/.*\/sfdx_core\/local\/package\.json$/)))
+        .returns(true)
+        .withArgs(sinon.match(sinon.match(/.*jest.config.js$/)))
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       stubMethod($$.SANDBOX, Setup.prototype, 'updatePackageJsonScripts');
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson').returns({
@@ -300,15 +301,12 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path.indexOf('package.json') !== -1) {
-          return true;
-        }
-        if (path.indexOf('forceignore') !== -1) {
-          return false;
-        }
-        return true;
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match(sinon.match(/.*\/sfdx_core\/local\/package\.json$/)))
+        .returns(true)
+        .withArgs(sinon.match(sinon.match(/.*forceignore.*/)))
+        .returns(false);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, Setup.prototype, 'getFileWriter').returns(fileWriterStub);
       stubMethod($$.SANDBOX, Setup.prototype, 'updatePackageJsonScripts');
       stubMethod($$.SANDBOX, Setup.prototype, 'getPackageJson');
@@ -333,12 +331,12 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path.indexOf('package.json') !== -1) {
-          return true;
-        }
-        return true;
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match(sinon.match(/.*\/sfdx_core\/local\/package\.json$/)))
+        .returns(true)
+        .withArgs(sinon.match(sinon.match(/.*forceignore.*/)))
+        .returns(true);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, fs, 'readFileSync').callsFake(path => {
         if (path.indexOf('forceignore') !== -1) {
           return "from test";
@@ -369,12 +367,12 @@ describe('force:lightning:lwc:test:setup', () => {
           return VALID_NPM_VERSION_STDOUT;
         }
       });
-      stubMethod($$.SANDBOX, fs, 'existsSync').callsFake(path => {
-        if (path.indexOf('package.json') !== -1) {
-          return true;
-        }
-        return true;
-      });
+      stubMethod($$.SANDBOX, fs, 'existsSync')
+        .withArgs(sinon.match(sinon.match(/.*\/sfdx_core\/local\/package\.json$/)))
+        .returns(true)
+        .withArgs(sinon.match(sinon.match(/.*forceignore.*/)))
+        .returns(true);
+      (fs.existsSync as SinonStub).callThrough();
       stubMethod($$.SANDBOX, fs, 'readFileSync').callsFake(path => {
         if (path.indexOf('forceignore') !== -1) {
           return "**/__tests__/**";

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,15 +278,6 @@
     debug "^4.1.1"
     semver "^7.3.2"
 
-"@oclif/config@1.13.3":
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.13.3.tgz#1b13e18d0e4242ddbd9cbd100f0eec819aa2bf8c"
-  integrity sha512-qs5XvGRw+1M41abOKCjd0uoeHCgsMxa2MurD2g2K8CtQlzlMXl0rW5idVeimIg5208LLuxkfzQo8TKAhhRCWLg==
-  dependencies:
-    "@oclif/parser" "^3.8.0"
-    debug "^4.1.1"
-    tslib "^1.9.3"
-
 "@oclif/config@^1", "@oclif/config@^1.14.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.14.0.tgz#0af93facd5c5087f804489f1603c4f3bc0c45014"


### PR DESCRIPTION
Updates `@oclif/config` to the latest and fixes the tests.

The reason the tests started failing is because they had very generic mocks for `fs.existsSync` – e.g. returning true whenever it's called. This started failing in `@oclif/config` v1.14.0 because of [this line](https://github.com/oclif/config/blob/0779d64dedc5a3a0dee28376971c0e42715c4d36/src/util.ts#L18), which is trying to locate an existing `package.json` file.

If we returned `true` regardless of input, then `@oclif/config` would end up with a file that didn't exist, so it would throw an error when it tried to read from it. This isn't the usage of `fs.existsSync` we were trying to stub, so I made the mocks a bit more precise.