### PR TITLE
fix: removes .html file validation

### DIFF
--- a/messages/create.json
+++ b/messages/create.json
@@ -7,6 +7,5 @@
   "errorFileNotFound": "File not found: '%s'.",
   "errorFileNotJs": "File must be a JavaScript file. The '.js' extension was not found: '%s'.",
   "errorFileExists": "Test file already exists: '%s'.",
-  "errorHtmlFileNotFound": "No corresponding HTML file found for '%s'. This command only supports Lightning web components with corresponding HTML and JavaScript files in the same directory.",
   "logSuccess": "Test case successfully created: %s"
 }

--- a/src/commands/force/lightning/lwc/test/create.ts
+++ b/src/commands/force/lightning/lwc/test/create.ts
@@ -44,11 +44,6 @@ export default class Create extends SfdxCommand {
       throw new SfdxError(messages.getMessage('errorFileNotFound', [this.flags.filepath]));
     }
 
-    const htmlPath = modulePath.substring(0, modulePath.lastIndexOf('.')) + '.html';
-    if (!fs.existsSync(htmlPath)) {
-      throw new SfdxError(messages.getMessage('errorHtmlFileNotFound', [this.flags.filepath]));
-    }
-
     const bundlePath = path.dirname(modulePath);
     const testDirPath = path.join(bundlePath, testDirName);
 

--- a/test/commands/lwc/test/create.test.ts
+++ b/test/commands/lwc/test/create.test.ts
@@ -59,6 +59,24 @@ describe('force:lightning:lwc:test:create', () => {
     });
 
     test
+      .do(() => {
+        stubMethod($$.SANDBOX, fs, 'existsSync')
+          .withArgs(sinon.match.in(['/path/to/js/foo.js']))
+          .returns(true)
+          .withArgs('/path/to/js/__tests__/foo.test.js')
+          .returns(false);
+        (fs.existsSync as SinonStub).callThrough();
+        stubMethod($$.SANDBOX, fs, 'mkdirSync');
+        writeFileSyncStub = stubMethod($$.SANDBOX, fs, 'writeFileSync');
+      })
+      .stdout()
+      .withProject()
+      .command(['force:lightning:lwc:test:create', '-f', '/path/to/js/foo.js'])
+      .it('creates test file in __tests__ folder of component bundle when .html file is missing', ctx => {
+        expect(writeFileSyncStub.args[0][0]).to.equal('/path/to/js/__tests__/foo.test.js');
+      });
+
+    test
     .do(() => {
       stubMethod($$.SANDBOX, fs, 'existsSync')
         .withArgs(sinon.match.in(['/path/to/js/foo.js', '/path/to/js/foo.html']))


### PR DESCRIPTION
This PR fixes https://github.com/forcedotcom/cli/issues/1254 by removing the validation for the existence of `${moduleName}.html` to verify the module is a component.

The validation of the existence of the `${moduleName}.html` file falls short in some cases:
1. When the component module uses the render method: importing template files that may have a different name from the module name.
2. The component inherits from another one and does not override the template (e.g., headless actions)

**Note**: a more robust validation will be to parse the module .js file and expect that the default export extends another class, but I don't think the benefits will be worth the effort.